### PR TITLE
Remove const in exported enums

### DIFF
--- a/src/messages/Level.ts
+++ b/src/messages/Level.ts
@@ -1,7 +1,7 @@
 /**
  * The level of the message.
  */
-const enum Level {
+enum Level {
   Error,
   Warning,
   Information,


### PR DESCRIPTION
Exported enums could be used with JS projects, but const enums are erased by TS.